### PR TITLE
[Core] Update to beta 1 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,19 +27,23 @@ jobs:
           python -m pytest -v ./tests
 
   test:
-    name: ${{ matrix.os }} ${{ matrix.python }}
+    name: ${{ matrix.os }} ${{ matrix.python }} ${{ matrix.openassetio }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python: ["3.7", "3.9", "3.10"]
+        # We use a deprecation for demonstrative purposes, so test
+        # before/after
+        openassetio: ["\"openassetio==1.0.0a14\"", "\"openassetio>=1.0.0b1.rev0\""]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - run: |
+          python -m pip install ${{ matrix.openassetio }}
           python -m pip install .
           python -m pip install -r tests/requirements.txt
           python -m pytest -v ./tests

--- a/plugin/my_asset_manager/MyAssetManagerInterface.py
+++ b/plugin/my_asset_manager/MyAssetManagerInterface.py
@@ -11,7 +11,13 @@ This is the entry-point for the logic of your asset manager.
 # the this class. See the notes under the "Initialization" section of:
 # https://openassetio.github.io/OpenAssetIO/classopenassetio_1_1v1_1_1manager_api_1_1_manager_interface.html#details (pylint: disable=line-too-long)
 # As such, any expensive module imports should be deferred.
-from openassetio import constants, BatchElementError, TraitsData
+from openassetio import constants, TraitsData, BatchElementError
+
+# TraitsData and BatchElementError got moved with a deprecation. If you
+# don't need to support versions prior to beta 1.0, you should use the
+# below two imports instead.
+# from openassetio.traits import TraitsData
+# from openassetio.errors import BatchElementError
 from openassetio.access import PolicyAccess, ResolveAccess
 from openassetio.managerApi import ManagerInterface
 from openassetio_mediacreation.traits.content import LocatableContentTrait
@@ -52,6 +58,19 @@ class MyAssetManagerInterface(ManagerInterface):
 
     def displayName(self):
         return "My Asset Manager"
+
+    def hasCapability(self, capability):
+        # Declare what sort of capabilities your manger fulfils.
+        # EntityReferenceIdentification and ManagementPolicyQueries
+        # are mandatory.
+        if capability in (
+            ManagerInterface.Capability.kEntityReferenceIdentification,
+            ManagerInterface.Capability.kManagementPolicyQueries,
+            ManagerInterface.Capability.kResolution,
+        ):
+            return True
+
+        return False
 
     def info(self):
         # This hint allows the API middleware to short-circuit calls to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ name = "my_asset_manager"
 version = "1.0.0"
 requires-python = ">=3.7"
 dependencies = [
-    "openassetio == 1.0.0a14",
+    "openassetio >= 1.0.0a14",
     "openassetio-mediacreation == 1.0.0a7"
 ]
 


### PR DESCRIPTION
Update the template to work with openassetio 1.0.0b1.post0 This includes declaring capabilities, as is now required. Also leave a note about the deprecated types, as managers may not desire deprecations in their code.

Tests both alpha and beta. The example is implemented with the deprecation in place, but has text explaining the reason and giving advice.