### PR TITLE
Add Entity Traits Method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,23 +27,19 @@ jobs:
           python -m pytest -v ./tests
 
   test:
-    name: ${{ matrix.os }} ${{ matrix.python }} ${{ matrix.openassetio }}
+    name: ${{ matrix.os }} ${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python: ["3.7", "3.9", "3.10"]
-        # We use a deprecation for demonstrative purposes, so test
-        # before/after
-        openassetio: ["\"openassetio==1.0.0a14\"", "\"openassetio>=1.0.0b1.rev0\""]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - run: |
-          python -m pip install ${{ matrix.openassetio }}
           python -m pip install .
           python -m pip install -r tests/requirements.txt
           python -m pytest -v ./tests

--- a/README.md
+++ b/README.md
@@ -143,18 +143,18 @@ Test directory, assumes a `pytest` testing environment. Uses the
 harness](https://openassetio.github.io/OpenAssetIO/testing.html#testing_manager_plugins)
 to run apiCompliance checks, as well as business logic tests.
 
-- [`business_logic_suite.py`](test/business_logic_suite.py): Tests for
+- [`business_logic_suite.py`](tests/business_logic_suite.py): Tests for
 the behaviour of the manager. Does it resolve assets correctly, etc.
 Invoked from `tests.py`
-- [`conftest.py`](test/conftest.py): Pytest fixtures necessary for
+- [`conftest.py`](tests/conftest.py): Pytest fixtures necessary for
   running the tests.
-- [`fixtures.py`](test/fixtures.py): Data concerning the manager
+- [`fixtures.py`](tests/fixtures.py): Data concerning the manager
 necessary to run the test harness. See [the
 documentation.](https://openassetio.github.io/OpenAssetIO/testing.html#testing_manager_plugins_fixtures)
-- [`requirements.txt`](test/requirements.txt): Requirements necessary to
+- [`requirements.txt`](tests/requirements.txt): Requirements necessary to
 run the tests. Generally installed with `python -m pip install -r
 tests/requirements.txt` from the root directory.
-- [`tests.py`](test/tests.py): Main test entry point. Executes the
+- [`test_manager.py`](tests/test_manager.py): Main test entry point. Executes the
  manager `business_logic_suite`, as well as [OpenAssetIOs
  apiComplianceSuite.](https://github.com/OpenAssetIO/OpenAssetIO/blob/main/src/openassetio-python/package/openassetio/test/manager/apiComplianceSuite.py)
 

--- a/plugin/my_asset_manager/MyAssetManagerInterface.py
+++ b/plugin/my_asset_manager/MyAssetManagerInterface.py
@@ -11,13 +11,9 @@ This is the entry-point for the logic of your asset manager.
 # the this class. See the notes under the "Initialization" section of:
 # https://openassetio.github.io/OpenAssetIO/classopenassetio_1_1v1_1_1manager_api_1_1_manager_interface.html#details (pylint: disable=line-too-long)
 # As such, any expensive module imports should be deferred.
-from openassetio import constants, TraitsData, BatchElementError
-
-# TraitsData and BatchElementError got moved with a deprecation. If you
-# don't need to support versions prior to beta 1.0, you should use the
-# below two imports instead.
-# from openassetio.traits import TraitsData
-# from openassetio.errors import BatchElementError
+from openassetio import constants
+from openassetio.trait import TraitsData
+from openassetio.errors import BatchElementError
 from openassetio.access import PolicyAccess, ResolveAccess, EntityTraitsAccess
 from openassetio.managerApi import ManagerInterface
 from openassetio_mediacreation.traits.content import LocatableContentTrait

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ name = "my_asset_manager"
 version = "1.0.0"
 requires-python = ">=3.7"
 dependencies = [
-    "openassetio >= 1.0.0a14",
-    "openassetio-mediacreation == 1.0.0a7"
+    "openassetio>=1.0.0b1.rev0",
+    "openassetio-mediacreation == 1.0.0a8"
 ]
 
 authors = [

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -6,7 +6,8 @@ Manager test harness test case fixtures for My Asset Manager.
 """
 from openassetio import constants
 from openassetio_mediacreation.traits.content import LocatableContentTrait
-
+from openassetio_mediacreation.traits.application import ConfigTrait
+from openassetio_mediacreation.traits.usage import EntityTrait
 
 IDENTIFIER = "myorg.manager.my_asset_manager"
 
@@ -14,6 +15,10 @@ VALID_REF = "my_asset_manager:///AssetIdentifier"
 NON_REF = "not a Ŕeference"
 MALFORMED_REF = "my_asset_manager:///AssetIdentifier?unsupportedQueryParam"
 EXISTING_REF = "my_asset_manager:///anAsset"
+MISSING_ENTITY_REF = "my_asset_manager:///missing_entity"
+ERROR_MSG_MALFORMED_REF = "Entity identifier is malformed"
+ERROR_MSG_MISSING_ENTITY = "Entity 'my_asset_manager:///missing_entity' not found"
+ERROR_READ_ONLY_ACCESS = "Entities are read-only"
 
 # This dictionary serves as expected outputs for the OpenAssetIO api
 # compliance suite. This suite tests that your implementation functions
@@ -39,12 +44,41 @@ fixtures = {
             "a_set_of_valid_traits": {LocatableContentTrait.kId},
             "a_reference_to_a_readonly_entity": EXISTING_REF,
             "the_error_string_for_a_reference_to_a_readonly_entity": "Entities are read-only",
-            "a_reference_to_a_missing_entity": "my_asset_manager:///missing_entity",
+            "a_reference_to_a_missing_entity": MISSING_ENTITY_REF,
             "the_error_string_for_a_reference_to_a_missing_entity": (
                 "Entity 'my_asset_manager:///missing_entity' not found"
             ),
             "a_malformed_reference": MALFORMED_REF,
             "the_error_string_for_a_malformed_reference": "Entity identifier is malformed",
         }
+    },
+    "Test_entityTraits": {
+        "shared": {
+            "a_reference_to_a_readonly_entity": EXISTING_REF,
+            "a_reference_to_a_missing_entity": MISSING_ENTITY_REF,
+            "a_malformed_reference": MALFORMED_REF,
+        },
+        "test_when_querying_malformed_reference_then_malformed_reference_error_is_returned": {
+            "expected_error_message": ERROR_MSG_MALFORMED_REF,
+        },
+        "test_when_querying_missing_reference_for_read_then_resolution_error_is_returned": {
+            "expected_error_message": ERROR_MSG_MISSING_ENTITY
+        },
+        "test_when_read_only_entity_queried_for_write_then_access_error_is_returned": {
+            "expected_error_message": ERROR_READ_ONLY_ACCESS
+        },
+        "test_when_multiple_references_for_read_then_same_number_of_returned_trait_sets": {
+            "first_entity_reference": "my_asset_manager:///anAsset",
+            "second_entity_reference": "my_asset_manager:///anAsset2",
+            "first_entity_trait_set": {
+                EntityTrait.kId,
+                LocatableContentTrait.kId,
+            },
+            "second_entity_trait_set": {
+                EntityTrait.kId,
+                LocatableContentTrait.kId,
+                ConfigTrait.kId,
+            },
+        },
     },
 }


### PR DESCRIPTION
#18 #8 

Jumped on this because EntityTraits is a mandatory method for the beta, and needs to exist if the template is going to be useful.

I did make an effort, but on reflection I think the template would be made quite unreadable if we tried to implement this maintaining support for both alpha and beta as we have been, so I have reluctantly removed alpha support along with this.

Also rolled in a commit fixing readme links, which is the thing that made me discover we'd forgotten this.