### PR TITLE
[CI] Add Markdown links check

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -42,3 +42,9 @@ jobs:
 
       - name: Check Python formatting
         run: black --check .
+
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
https://github.com/OpenAssetIO/OpenAssetIO/issues/737 
Validate that markdown links are valid in CI.