### PR TITLE
[CI] Use x86 MacOS runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
+        os: ["windows-latest", "ubuntu-latest", "macos-13"]
         python: ["3.7", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub changed `macos-latest` to be an ARM runner. Until we have MacOS ARM wheels (OpenAssetIO/OpenAssetIO#718) we must pin to the last x86 runner version.