### PR TITLE
[Build] Bump MediaCreation to 1.0.0-alpha.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version = "1.0.0"
 requires-python = ">=3.7"
 dependencies = [
     "openassetio>=1.0.0b1.rev0",
-    "openassetio-mediacreation == 1.0.0a8"
+    "openassetio-mediacreation >= 1.0.0a9"
 ]
 
 authors = [


### PR DESCRIPTION
Part of OpenAssetIO/OpenAssetIO#1311. Deprecated aliases have been removed from the latest OpenAssetIO, but the version of MediaCreation that was pinned in `pyproject.toml` still used them.

So bump the version of MediaCreation to the latest.