### PR TITLE
Default to CY24 and drop support for CY22

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build_wheels:
     name: Build wheel
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install dependencies
         run: |
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   publish_testpypi:
     name: Publish distribution 📦 to TestPyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download wheels from commit ${{ github.sha }}
         uses: dawidd6/action-download-artifact@v6
@@ -35,7 +35,7 @@ jobs:
   publish_pypi:
     name: Publish distribution 📦 to PyPI
     needs: publish_testpypi
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download wheels from commit ${{ github.sha }}
         uses: dawidd6/action-download-artifact@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - run: |
           grep -RIl 'MyAssetManager' | xargs sed -i 's/MyAssetManager/RenamedAssetManager/g'
           grep -RIl 'my_asset_manager' | xargs sed -i 's/my_asset_manager/renamed_asset_manager/g'
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-13"]
-        python: ["3.7", "3.9", "3.10"]
+        python: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "my_asset_manager"
 version = "1.0.0"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = [
     "openassetio>=1.0.0b1.rev0",
     "openassetio-mediacreation >= 1.0.0a9"


### PR DESCRIPTION
Part of OpenAssetIO/OpenAssetIO#1351. Use CI runner and Python version the best matches VFX Reference Platform CY24. Hence drop support for CY22.