### PR TITLE
[CI] Bump MacOS GitHub runner version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "ubuntu-latest", "macos-13"]
+        os: ["windows-latest", "ubuntu-latest", "macos-15-intel"]
         python: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Part of OpenAssetIO/OpenAssetIO#1480.

GitHub have deprecated their macos-13 runners, so we must bump to a later MacOS version for CI tests.

Note: until https://github.com/OpenAssetIO/OpenAssetIO/pull/1481 is merged and OpenAssetIO is released, we must still rely on MacOS Intel (rather than ARM) in this repo.

We choose macos-15-intel because
* 15 is the latest, and we want maximum time before having to deal with another deprecation.
* Intel because at time of writing we still don't build `openassetio` wheels for MacOS ARM.